### PR TITLE
Update POST for new palette

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -77,11 +77,11 @@ app.post('/api/v1/projects', async (request, response) => {
 app.post('/api/v1/palettes', async (request, response) => {
   const palette = request.body;
 
-  for (let requiredParameter of ['name', 'color1', 'color2', 'color3', 'color4', 'color5',]) {
+  for (let requiredParameter of ['name', 'project_id', 'color1', 'color2', 'color3', 'color4', 'color5']) {
     if (!palette[requiredParameter]) {
       return response
         .status(422)
-        .send({ error: `Expected format: { name: <string>, color1, <string>, color2, <string>, color3, <string>, color4, <string>, color5, <string>, }. You are missing a ${requiredParameter} property.` })
+        .send({ error: `Expected format: { name: <string>, color1: <string>, color2: <string>, color3: <string>, color4: <string>, color5: <string>, project_id: <integer> }. You are missing a ${requiredParameter} property.` })
     }
   }
 

--- a/app/app.test.js
+++ b/app/app.test.js
@@ -133,13 +133,17 @@ describe('Server', () => {
 
   describe('POST /api/v1/palettes', () => {
     it('should return a 200 and add a new palette to the table', async () => {
+      const expectedProject = await database('projects').first();
+      const id = expectedProject.id;
+
       const newPalette = { 
-        name: 'Christmas Theme', 
+        name: 'Christmas Theme',
+        project_id: id, 
         color1: '#FFFFFF', 
         color2: '#FFFFFF',
         color3: '#FFFFFF',
         color4: '#FFFFFF',
-        color5: '#FFFFFF'
+        color5: '#FFFFFF',
       };
 
       const res = await request(app).post('/api/v1/palettes').send(newPalette);
@@ -152,8 +156,12 @@ describe('Server', () => {
     });
 
     it('should return a 422 and a message when missing parameter', async () => {
+      const expectedProject = await database('projects').first();
+      const id = expectedProject.id;
+
       const newPalette = {
         name: 'Christmas Theme',
+        project_id: id,
         color1: '#FFFFFF',
         color3: '#FFFFFF',
         color4: '#FFFFFF',
@@ -162,7 +170,7 @@ describe('Server', () => {
       const res = await request(app).post('/api/v1/palettes').send(newPalette);
 
       expect(res.status).toBe(422);
-      expect(res.body.error).toEqual('Expected format: { name: <string>, color1, <string>, color2, <string>, color3, <string>, color4, <string>, color5, <string>, }. You are missing a color2 property.')
+      expect(res.body.error).toEqual('Expected format: { name: <string>, color1: <string>, color2: <string>, color3: <string>, color4: <string>, color5: <string>, project_id: <integer> }. You are missing a color2 property.')
     });
   });
 


### PR DESCRIPTION
#### What's this PR do?
During our standup we noticed that the "project_id" was missing from the test for the palette posting. Thus I've added it as a required parameter and added to the test post request.

#### How should this be manually tested?
Tests have been fixed and all are passing.

#### Any background context you want to provide?
Now the POST will check that this key is included in the request object.
