### PR TITLE
Query param "project_id"

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -32,11 +32,18 @@ app.get('/api/v1/projects/:id', async (request, response) => {
 
 app.get('/api/v1/palettes', async (request, response) => {
   const palettes = await database('palettes').select();
-  const { name } = request.query;
+  const { name, project_id } = request.query;
   if (name) {
     const queriedPalette = await database('palettes').where('name', 'like', `%${name}%`).select();
     if (queriedPalette.length) {
-      return response.status(200).json(queriedPalette[0])
+      return response.status(200).json(queriedPalette)
+    } else {
+      return response.status(404).json({ error: 'That palette does not exist.' })
+    }
+  } else if (project_id) {
+    const queriedPalette = await database('palettes').where('project_id', project_id).select();
+    if (queriedPalette.length) {
+      return response.status(200).json(queriedPalette)
     } else {
       return response.status(404).json({ error: 'That palette does not exist.' })
     }

--- a/app/app.test.js
+++ b/app/app.test.js
@@ -71,10 +71,19 @@ describe('Server', () => {
       const paletteName = targetPalette.name;
 
       const res = await request(app).get(`/api/v1/palettes?name=${paletteName}`);
-      console.log(res.body)
 
       expect(res.status).toBe(200);
-      expect(res.body.name).toEqual(paletteName)
+      expect(JSON.stringify(res.body)).toEqual(JSON.stringify([targetPalette]))
+    })
+
+    it('should return a 200 and palette based on the query param provided', async () => {
+      const targetPalette = await database('palettes').first();
+      const projectId = targetPalette.project_id;
+
+      const res = await request(app).get(`/api/v1/palettes?project_id=${projectId}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.length).toEqual(2)
     })
 
     it('should return a 404 and an error message', async () => {


### PR DESCRIPTION
#### What's this PR do?
Adds a test and functionality for a query param for project_id.

#### How should this be manually tested?
Test was completed prior to updating endpoint

#### Any background context you want to provide?
After further review on the FE, we realized that we would need a query param to select palettes based on their project_id.
