### PR TITLE
Update post projects endpoint to error when new project name already exists

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -71,10 +71,15 @@ app.post('/api/v1/projects', async (request, response) => {
         .send({ error: `Expected format: { name: <string> }. You are missing a ${requiredParameter} property.` })
     } 
   }
+  const alreadyExists = await database('projects').where('name', project.name).select()
+  console.log(alreadyExists)
+  if (alreadyExists.length) {
+    return response.status(422).json({ error: `${project.name} already exists, please choose a new name.` })
+  }
 
   const insertedProject = await database('projects').insert(project, 'id');
 
-  if (insertedProject) {
+  if (!alreadyExists.length && insertedProject) {
     return response.status(201).json({ id: insertedProject[0] });
   } else {
     return response.status(422).json({ error: 'Failed to post project' })


### PR DESCRIPTION
#### What's this PR do?
This PR adds functionality to the POST Projects endpoint, so that projects can only be posted if it is a unique name (does not already exist in the database).

#### Where should the reviewer start?
Changes were made in the app file in the POST projects method
